### PR TITLE
fix for unicode issue and non-standard names

### DIFF
--- a/catkin_tools_python/create_python_package_xmls.py
+++ b/catkin_tools_python/create_python_package_xmls.py
@@ -23,6 +23,10 @@ from tempfile import mkdtemp
 
 from catkin_tools_python import filters
 
+# fix for em unicode handling
+em.str = unicode
+em.Stream.write_old = em.Stream.write
+em.Stream.write = lambda self, data: em.Stream.write_old(self, data.encode('utf8'))
 
 PACKAGE_XML_TEMPLATE = '''<?xml version="1.0"?>
 <package format="2">

--- a/catkin_tools_python/filters.py
+++ b/catkin_tools_python/filters.py
@@ -15,7 +15,9 @@
 mapping = {
     'PIL': 'python-imaging',
     'pyserial': 'python-serial',
-    'PyYAML': 'python-yaml'
+    'PyYAML': 'python-yaml',
+    'dxfgrabber': 'dxfgrabber',
+    'progressbar2': 'python-progressbar'
 }
 
 comparisons = {


### PR DESCRIPTION
fixes for initial run.

- em.py unicode issue
- filters.py for naming of non-standard packages