### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
   - catkin build
   - fix_python_script_shebangs install/bin
   - find install
-  - install/env.sh python -c 'import yaml; print yaml.__file__'
+  - install/env.sh python -c 'import yaml; print(yaml.__file__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: generic
 matrix:
   include:
-    - dist: trusty
+    - dist: xenial
       os: linux
-      env: PYTHON=/usr/bin/python2.7
+      env: PYTHON=/usr/bin/python3
     - os: osx
       env: PYTHON=/usr/bin/python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       os: linux
 
 install:
-  - virtualenv ~/venv /usr/bin/python3
+  - virtualenv ~/venv -p /usr/bin/python3
   - unset PYTHON
   - source ~/venv/bin/activate
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ matrix:
   include:
     - dist: xenial
       os: linux
-      env: PYTHON=/usr/bin/python3
-    - os: osx
-      env: PYTHON=/usr/bin/python
 
 install:
-  - virtualenv ~/venv -p $PYTHON
+  - virtualenv ~/venv /usr/bin/python3
   - unset PYTHON
   - source ~/venv/bin/activate
   - pip install --upgrade pip

--- a/catkin_tools_python/create_python_package_xmls.py
+++ b/catkin_tools_python/create_python_package_xmls.py
@@ -34,7 +34,6 @@ try:
 except NameError:
     pass
 
->>>>>>> remove unicode handling for python2 em
 PACKAGE_XML_TEMPLATE = '''<?xml version="1.0"?>
 <package format="2">
   <name>@(filters.name(pkginfo.name))</name>

--- a/catkin_tools_python/create_python_package_xmls.py
+++ b/catkin_tools_python/create_python_package_xmls.py
@@ -34,6 +34,7 @@ try:
 except NameError:
     pass
 
+>>>>>>> remove unicode handling for python2 em
 PACKAGE_XML_TEMPLATE = '''<?xml version="1.0"?>
 <package format="2">
   <name>@(filters.name(pkginfo.name))</name>
@@ -176,3 +177,4 @@ def main():
             sys.exit(1)
         for root in args.roots:
             create_package_xmls(root)
+

--- a/catkin_tools_python/create_python_package_xmls.py
+++ b/catkin_tools_python/create_python_package_xmls.py
@@ -176,4 +176,3 @@ def main():
             sys.exit(1)
         for root in args.roots:
             create_package_xmls(root)
-

--- a/catkin_tools_python/fix_python_script_shebangs.py
+++ b/catkin_tools_python/fix_python_script_shebangs.py
@@ -55,6 +55,6 @@ def main():
     args = get_arg_parser().parse_args()
     ret = fix_shebangs(args.bindir, args.python)
     if ret:
-        print "Modified %s script(s) found in [%s]" % (ret, args.bindir)
+        print("Modified %s script(s) found in [%s]" % (ret, args.bindir))
     else:
-        print "No scripts modified in [%s]" % args.bindir
+        print("No scripts modified in [%s]" % args.bindir)

--- a/catkin_tools_python/job.py
+++ b/catkin_tools_python/job.py
@@ -68,7 +68,7 @@ def fix_shebangs(logger, event_queue, pkg_dir, python_exec):
             # ensure we are using the correct python
             if re.match(b"#!/usr/bin/python(\s|$)", contents):
                 logger.out("Modifying shebang from global python to python exec")
-                contents = contents.replace(b'#!/usr/bin/python', new_shabang, 1)
+                contents = contents.replace(b'#!/usr/bin/python', new_shebang, 1)
                 modified = True
             elif re.match(b"#!/usr/bin/env python(\s|$)", contents):
                 logger.out("Modifying shebang from using env python to python exec")

--- a/catkin_tools_python/job.py
+++ b/catkin_tools_python/job.py
@@ -61,26 +61,23 @@ def fix_shebangs(logger, event_queue, pkg_dir, python_exec):
         if filename.endswith(('.py')):
             logger.out("Processing file ", filename)
             filepath = os.path.join(root, filename)
-            with open(filepath, 'r') as f:
-                try:
-                    contents = f.read()
-                except UnicodeDecodeError:
-                    logger.out("Unicode error caught skipping file : ", filepath)
-                    continue
+            with open(filepath, 'rb') as f:
+                contents = f.read()
 
+            new_shebang = ('#!%s' % python_exec).encode()
             # ensure we are using the correct python
-            if re.match("#!/usr/bin/python(\s|$)", contents):
+            if re.match(b"#!/usr/bin/python(\s|$)", contents):
                 logger.out("Modifying shebang from global python to python exec")
-                contents = contents.replace('#!/usr/bin/python', '#!%s' % python_exec, 1)
+                contents = contents.replace(b'#!/usr/bin/python', new_shabang, 1)
                 modified = True
-            elif re.match("#!/usr/bin/env python(\s|$)", contents):
+            elif re.match(b"#!/usr/bin/env python(\s|$)", contents):
                 logger.out("Modifying shebang from using env python to python exec")
-                contents = contents.replace('#!/usr/bin/env python', '#!%s' % python_exec, 1)
+                contents = contents.replace(b'#!/usr/bin/env python', new_shebang, 1)
                 modified = True
 
             if modified:
                 logger.out("Writing changes  to %s" % filename)
-                with open(filepath, 'w') as f:
+                with open(filepath, 'wb') as f:
                     f.write(contents)
 
     return 0
@@ -93,17 +90,17 @@ def fix_python3_install_space(logger, event_queue, install_space, old_python, ne
     """Modify the setup.sh in the python installs to have the correct PYTHONPATH
        :param: install_space: packages install space where the setup.sh script will be
     """
-    old_python_path = "/lib/python%s" % old_python
-    new_python_path = "/lib/python%s" % new_python
+    old_python_path = ("/lib/python%s" % old_python).encode()
+    new_python_path = ("/lib/python%s" % new_python).encode()
     filepath = os.path.join(install_space, "setup.sh")
     if os.path.exists(filepath):
-        with open(filepath, 'r') as f:
+        with open(filepath, 'rb') as f:
             contents = f.read()
             contents = contents.replace(old_python_path, new_python_path)
 
         if contents:
             logger.out("Modifying python path from %s to %s in %s" % (old_python_path, new_python_path, filepath))
-            with open(filepath, 'w') as f:
+            with open(filepath, 'wb') as f:
                 f.write(contents)
 
     return 0


### PR DESCRIPTION
Add python package support for python3.
- catkin defaults the pythonpath/install dir to the python major version instead of major.minor
- if we are passing in the python executable to use then all shebangs need to be forced to that shebang.

* Add support in travis to run under python3/xenial
* upgraded the standalone python tools for python3