### PR TITLE
Add support for pip install

### DIFF
--- a/catkin_tools_python/__init__.py
+++ b/catkin_tools_python/__init__.py
@@ -21,3 +21,10 @@ description = dict(
     create_build_job=create_python_build_job,
     create_clean_job=create_python_clean_job
 )
+
+pip_description = dict(
+    build_type='python-pip',
+    description='Builds a plain python package.',
+    create_build_job=create_python_build_job,
+    create_clean_job=create_python_clean_job
+)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         ],
         'catkin_tools.jobs': [
             'python = catkin_tools_python:description',
+            'python-pip = catkin_tools_python:pip_description',
         ]
     },
     install_requires=[


### PR DESCRIPTION
The request to pip install packages into the catkin workspace comes up every once in a while.
Instead of requiring a build with the setup.py and having the full source, this would give the ability for a user to define a package with a frozen requirements.txt file which we then install into the devel/install space. 

Example PackageA contains:
* package.xml with build-type set to python-pip: `<export><build_type>python-pip</build_type></export>`
* requirements.txt file with the packages required to be installed, preferably frozen to a version

Alternatively this could open it up to defining all of our python package requirements into one large requirements.txt file.

A new entry point `python-pip` was created.  I reused the same python build job definition as the install command is the only different option.

This currently only supports a straight install and more complex scenarios such as deviating package name or path are not supported.

@mikepurvis Looking for your input on this.